### PR TITLE
Documentation generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ public/assets
 package-lock.json
 instructions-database.txt
 .env
+/docs

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,33 @@
+{
+    "plugins": ["plugins/markdown"],
+    "recurseDepth": 10,
+    "source": {
+        "include": ["src/"],
+        "exclude": [
+            "node_modules",
+            "postcss.config.js",
+            "tailwind.config.js"
+        ],
+        "includePattern": ".+\\.js(doc|x)?$",
+        "excludePattern": "(^|\\/|\\\\)_"
+    },
+    "tags": {
+        "allowUnknownTags": true,
+        "dictionaries": ["jsdoc","closure"]
+    },
+    "templates": {
+        "cleverLinks": false,
+        "monospaceLinks": false
+    },
+    "opts": {
+        "encoding": "utf8",
+        "readme": "./README.md",
+        "destination": "docs/",
+        "recurse": true,
+        "verbose": true,
+        "template": "./node_modules/clean-jsdoc-theme",
+        "theme_opts": {
+            "theme": "dark"
+        }
+    }   
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "nodemon ./src/server.js",
     "build:css": "postcss src/resources/css/tailwind.css -o public/assets/output.css",
     "generate:key": "node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"",
+    "build:doc": "node_modules/.bin/jsdoc --configure jsdoc.json --verbose",
     "test": "jest"
   },
   "author": "P2",
@@ -15,6 +16,7 @@
     "@tailwindcss/forms": "^0.5.0",
     "@tailwindcss/typography": "^0.5.2",
     "bcrypt": "^5.0.1",
+    "clean-jsdoc-theme": "^3.3.4",
     "dotenv": "^16.0.0",
     "ejs": "^3.1.6",
     "express": "^4.17.3",
@@ -32,6 +34,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.2.0",
     "jest": "^27.5.1",
+    "jsdoc": "^3.6.10",
     "nodemon": "^2.0.15",
     "postcss": "^8.4.8",
     "standard": "^16.0.4",


### PR DESCRIPTION
Documentation generator with JSDoc. Write `npm run build:doc` into the terminal to generate the documentation. 

