### PR TITLE
Projecthub logo

### DIFF
--- a/src/resources/views/project/_partial/header/_partial/logo.ejs
+++ b/src/resources/views/project/_partial/header/_partial/logo.ejs
@@ -1,4 +1,4 @@
-<a href="/" class="hover:cursor-pointer flex justify-center w-full">
+<a href="/projects" class="hover:cursor-pointer flex justify-center w-full">
   <h1 class="text-4xl mr-0.5 font-bold">
     Project
   </h1>


### PR DESCRIPTION
Remove the link from the ProjectHub Logo at the dashboard. This will not lead back to the homepage, which is nice. 