### PR TITLE
Session Re-save

### DIFF
--- a/src/config/session.js
+++ b/src/config/session.js
@@ -5,7 +5,7 @@ require('../database/mongo')
 const sess = {
     secret: process.env.SECRET_KEY,
     saveUninitialized: false, // don't create session until something stored
-    resave: false, // don't save session if unmodified
+    resave: true, // don't save session if unmodified
     // rolling: true, //Reset the cookie Max-Age on every request
     cookie: {
         maxAge: 24 * 60 * 60 * 1000, // 24 hours


### PR DESCRIPTION
It is recommended to have this set as true.

What this does is tell the session store that a particular session is still active, which is necessary because some stores will delete idle (unused) sessions after some time.

